### PR TITLE
Removed "Player 'color' Wins" message

### DIFF
--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -390,9 +390,9 @@ function results(obj, color, alt_click)
     return
   end
 
-  local message = 'Player '..color..' Wins!'
-  broadcastToAll(message)
-  log(message)
+  -- local message = 'Player '..color..' Wins!'
+  -- broadcastToAll(message)
+  -- log(message)
   local zoneObjects = fieldZone.getObjects()
   local i = 0
   local winPlacement = players[color].winPile.getPosition()


### PR DESCRIPTION
Removed the player wins message when the results button is pressed. It overlaps with the bonus card message and otherwise makes the points message harder to read.