### PR TITLE
Make some quality of life changes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,14 @@ This document tracks all notables changes of Havoc Tabletop Simulator Edition.
 
 ---
 
+## v0.6.3 Quality of Life Changes
+
+### Changed
+
+- Update Sum button to display the number of cards in respective zones
+
+---
+
 ## v0.6.2 Shorten Rounds Notebook Message
 
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ This document tracks all notables changes of Havoc Tabletop Simulator Edition.
 ### Changed
 
 - Update Sum button to display the number of cards in respective zones
+- Update Reset button to show round data before resetting
+  - Shows the number of rounds played, plus the points and number of cards that are in each player's win pile and discard
 
 ---
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,9 +8,13 @@ This document tracks all notables changes of Havoc Tabletop Simulator Edition.
 
 ### Changed
 
-- Update Sum button to display the number of cards in respective zones
-- Update Reset button to show round data before resetting
-  - Shows the number of rounds played, plus the points and number of cards that are in each player's win pile and discard
+- Update Sum buttons to display the number of cards in their respective zones
+- Update Reset button to show game data before resetting
+  - Shows the number of rounds played, plus the points and number of cards that are in the win piles and discard
+
+### Fixed
+
+- Added a bit more randomization to cleared card positions to reduce the chance of overlapping cards from forming a deck
 
 ---
 

--- a/src/Buttons/ClearButton.ttslua
+++ b/src/Buttons/ClearButton.ttslua
@@ -49,20 +49,32 @@ end
 
 function moveCardsToDiscard()
     local fieldZoneObjects = fieldZone.getObjects()
-    local discardZonePosition = discardZone.getPosition()
     local i = 0
 
     for _, item in ipairs(fieldZoneObjects) do
       -- If in only field zone and the zone surrounding the whole game (so doesn't grab deck)
       if #item.getZones() == 2 then
-        local randomXOffset = math.random(DISCARD_X_OFFSET * 2 + 1) - DISCARD_X_OFFSET;
-        local randomYOffset = math.random(DISCARD_Y_OFFSET * 2 + 1) - DISCARD_Y_OFFSET;
-        local randomDiscardPosition = {discardZonePosition[1] + randomXOffset, discardZonePosition[2]+5+i, discardZonePosition[3] + randomYOffset}
-        item.setPositionSmooth(randomDiscardPosition, false, true)
+        -- Jitter is for 'shaking' the cards slightly to reduce a chance of exactly overlapping cards
+        local newPosition = getRandomDiscardPosition(i)
+        item.setPositionSmooth(newPosition, false, true)
         i = i + .8
       end
     end
 end
+
+function getRandomDiscardPosition(numIterations)
+  local discardZonePosition = discardZone.getPosition()
+  local randomXOffset = math.random(DISCARD_X_OFFSET * 2 + 1) - DISCARD_X_OFFSET;
+  local randomYOffset = math.random(DISCARD_Y_OFFSET * 2 + 1) - DISCARD_Y_OFFSET;
+  local xJitter = math.random() * 2 - 1
+  local yJitter = math.random() * 2 - 1
+
+  local newX = discardZonePosition[1] + randomXOffset + xJitter
+  local newZ = discardZonePosition[2] + 5 + numIterations
+  local newY = discardZonePosition[3] + randomYOffset + yJitter
+  return {newX, newZ, newY}
+end
+
 --[[
 ClearButton.ttslua END
 ]]

--- a/src/Buttons/ResetButton.ttslua
+++ b/src/Buttons/ResetButton.ttslua
@@ -64,10 +64,43 @@ function stopResetTimer()
 end
 
 function resetGame()
-  log('Game reset')
+  logGameData()
   resetPlayers()
   resetDeck()
   resetRoundsNotebook()
+  log('Game reset')
+end
+
+-- Log game data in case we forgot to trigger results buttons and check the notebook before resetting
+function logGameData()
+  broadcast('Rounds played: '..getRoundsPlayed())
+  logCardPileData('Orange')
+  logCardPileData('Blue')
+  logCardPileData('Discard')
+end
+
+function logCardPileData(targetName)
+  local params = nil
+
+  if targetName == 'Orange' then
+    params = {
+      zoneObjects = players['Orange'].winPile.getObjects()
+    }
+  elseif targetName == 'Blue' then
+    params = {
+      zoneObjects = players['Blue'].winPile.getObjects()
+    }
+  elseif targetName == 'Discard' then
+    params = {
+      zoneObjects = discardZone.getObjects()
+    }
+  else
+    return
+  end
+
+  params.zoneName = targetName
+  params.stopBroadcast = false
+  calculatePointsPrint(params)
 end
 
 function resetPlayers()

--- a/src/Buttons/ResultsButton.ttslua
+++ b/src/Buttons/ResultsButton.ttslua
@@ -4,7 +4,7 @@ ResultsButton.ttslua START
 This file contains functions that the reset button triggers.
 ]]
 
--- Sends cards on field to winner's Win Pile and proceedes to drawing phase
+-- Sends cards on field to winner's Win Pile and proceeds to drawing phase
 function createResultsButton()
   local bResults_vars = {
     click_function='results',

--- a/src/Havoc.ttslua
+++ b/src/Havoc.ttslua
@@ -136,7 +136,7 @@ function countCards(cardTable)
   local numCards = 0
 
   for name, cards in pairs(cardTable) do
-    numCards = numCards + 1
+    numCards = numCards + cards
   end
 
   return numCards

--- a/src/Havoc.ttslua
+++ b/src/Havoc.ttslua
@@ -145,6 +145,7 @@ end
 function calculatePointsPrint(params)
   local zoneObjects = params.zoneObjects
   local zoneName = params.zoneName
+  local stopBroadcast = params.stopBroadcast
   -- Count the cards in the zone
   local cardTable = {}
   for _, item in pairs(zoneObjects) do
@@ -178,9 +179,20 @@ function calculatePointsPrint(params)
     for _, card in pairs(bonusCards) do
       bonusMessage = bonusMessage..card..'s '
     end
-    broadcast(pointMessage..bonusMessage) -- Broadcast with bonusMessage (seems only one broadcast at a time)
+
+    -- Broadcast with bonusMessage (seems only one broadcast at a time)
+    if stopBroadcast then
+      log(pointMessage..bonusMessage)
+    else
+      broadcast(pointMessage..bonusMessage)
+    end
   else
-    broadcast(pointMessage) -- Broadcast without bonusMessage
+    -- Broadcast without bonusMessage
+    if stopBroadcast then
+      log(pointMessage)
+    else
+      broadcast(pointMessage)
+    end
   end
 end
 --[[

--- a/src/Havoc.ttslua
+++ b/src/Havoc.ttslua
@@ -109,9 +109,8 @@ function onLoad()
   setupShortcuts()
 end
 
--- Is this still used?
 --Given a table of cards, returns sum of points
---If bonusIsSeperate defined, then return sum and bonus seperately
+--If bonusIsSeparate defined, then return sum and bonus seperately
 function calculatePoints(cardTable, bonusIsSeparate)
   local bonusCards = {}
   local sum = 0 -- Normal sum
@@ -133,7 +132,16 @@ function calculatePoints(cardTable, bonusIsSeparate)
   end
 end
 
--- TODO Isn't actually used but should be used in other layout zones
+function countCards(cardTable)
+  local numCards = 0
+
+  for name, cards in pairs(cardTable) do
+    numCards = numCards + 1
+  end
+
+  return numCards
+end
+
 function calculatePointsPrint(params)
   local zoneObjects = params.zoneObjects
   local zoneName = params.zoneName
@@ -153,10 +161,17 @@ function calculatePointsPrint(params)
       end
     end
   end
-  -- Calculate total points and record bonus cards
+  -- Calculate total points, record bonus cards and num cards in zone
   local sum, bonusCards = calculatePoints(cardTable, true)
+  local numCards = countCards(cardTable)
+
   -- Base points message
   local pointMessage = zoneName..' has '..sum..' points'
+
+  if (numCards > 0) then
+    pointMessage = pointMessage..' and '..numCards..' cards'
+  end
+
   -- Bonuses gained
   if #bonusCards > 0 then --There is at least a bonus
     local bonusMessage = '\nFour of a Kind: ' -- "Hello" "World" "HelloWorld"

--- a/src/Notebook.ttslua
+++ b/src/Notebook.ttslua
@@ -25,7 +25,7 @@ function addRoundNote(note)
   local numberIndexEnd = 0
   local numberIndexStart = 0
   local lineNumber = 0
-  
+
   if roundsTabBody:match'^.*():' != nil and roundsTabBody:match'^.*()\n' != nil then -- If there is a previous line
     numberIndexEnd = roundsTabBody:match'^.*():' - 1
     numberIndexStart = roundsTabBody:match'^.*()\n'
@@ -47,6 +47,19 @@ function resetRoundsNotebook()
     index = ROUNDS_TAB_INDEX,
     body = STARTING_ROUNDS_NOTEBOOK_LINE
   })
+end
+
+function getRoundsPlayed()
+  local roundsTabBody = Notes.getNotebookTabs()[ROUNDS_TAB_INDEX+1].body
+
+  if roundsTabBody:match'^.*():' == nil or roundsTabBody:match'^.*()\n' == nil then
+    return 0
+  end
+
+  local numberIndexEnd = roundsTabBody:match'^.*():' - 1
+  local numberIndexStart = roundsTabBody:match'^.*()\n'
+  local roundsPlayed = tonumber(string.sub(roundsTabBody, numberIndexStart, numberIndexEnd))
+  return roundsPlayed
 end
 
 --[[


### PR DESCRIPTION
Adds some quality of life changes to make playing Havoc easier. Mainly to do with displaying information for statistics purposes.

- Update sum buttons to display the number of cards in their respective zones
- Update reset button to show game data before resetting
- Randomize cleared card positions a bit more to reduce the chance of overlapping cards from forming a deck