### PR TITLE
Fix manual-notebook-modification bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,9 @@ This document tracks all notables changes of Havoc Tabletop Simulator Edition.
 ### Fixed
 
 - Tablet now displays rules again
+- Fix bug where Results, Clear and Reset buttons stop working after manually modifying the Rounds notebook
+  - Specifically by entering a newline at the end of the notebook
+- Fix bug where a nil operation error appears whenever a player attempts to bet when the deck is empty
 
 ### Removed
 

--- a/src/Buttons/BetButton.ttslua
+++ b/src/Buttons/BetButton.ttslua
@@ -74,18 +74,25 @@ function playerBet(player_color, bet_color)
     return
   end
 
-  log('Player '..bet_color..' bets')
-  moveCardToBetZone(bet_color)
-  players[bet_color].betState = true
-  local betPlacement = players[bet_color].betPos
-  deleteButtonHere(betPlacement)
+  if getDeck() != nil then
+    log('Player '..bet_color..' bets')
+    moveCardToBetZone(bet_color)
+    players[bet_color].betState = true
+    local betPlacement = players[bet_color].betPos
+    deleteButtonHere(betPlacement)
+  end
 end
 
 function moveCardToBetZone(bet_color)
   -- Bet button's place and bet card's place are the same
   local betPlacement = players[bet_color].betPos
+  local deck = getDeck()
 
-  getDeck().takeObject({
+  if deck == nil then
+    return
+  end
+
+  deck.takeObject({
     --Have to flip x cordinate because the takeObject position flips the x value
     position = {-betPlacement[1],betPlacement[2],betPlacement[3]},
     rotation = {0,0,0},

--- a/src/Buttons/ResetButton.ttslua
+++ b/src/Buttons/ResetButton.ttslua
@@ -74,7 +74,13 @@ end
 
 -- Log game data in case we forgot to trigger results buttons and check the notebook before resetting
 function logGameData()
-  broadcast('Rounds played: '..getRoundsPlayed())
+  local latestRoundNumber = getLatestRoundNumber()
+
+  if latestRoundNumber == nil then
+    latestRoundNumber = 0
+  end
+
+  broadcast('Rounds played: '..tostring(latestRoundNumber))
   logCardPileData('Orange')
   logCardPileData('Blue')
   logCardPileData('Discard')

--- a/src/Notebook.ttslua
+++ b/src/Notebook.ttslua
@@ -18,28 +18,47 @@ This file contains notebook-related functions.
 
 -- Adds a new line to Rounds Notebook tab
 function addRoundNote(note)
+
+  local roundsTabBody = Notes.getNotebookTabs()[ROUNDS_TAB_INDEX+1].body
+  local lineNumber = 1
+  local lastRoundNum = getLatestRoundNumber()
+
+  if lastRoundNum != nil then
+    lineNumber = lastRoundNum + 1
+  end
+
   -- Get the Notebook array, Get the Rounds Tab from index, get body of Rounds Tab
   -- Plus one because arrays count from 1, but Notebook Index counts from 0
   local roundsTabBody = Notes.getNotebookTabs()[ROUNDS_TAB_INDEX+1].body
-  -- Get location of line Number in the Body String
-  local numberIndexEnd = 0
-  local numberIndexStart = 0
-  local lineNumber = 0
-
-  if roundsTabBody:match'^.*():' != nil and roundsTabBody:match'^.*()\n' != nil then -- If there is a previous line
-    numberIndexEnd = roundsTabBody:match'^.*():' - 1
-    numberIndexStart = roundsTabBody:match'^.*()\n'
-    lineNumber = tonumber(string.sub(roundsTabBody, numberIndexStart, numberIndexEnd)) + 1
-  else -- The rounds notebook is empty
-    lineNumber = 1
-  end
 
   Notes.editNotebookTab({
     index = ROUNDS_TAB_INDEX,
-    body = roundsTabBody..'\n'..lineNumber..': '..note
+    body = removeNewlinesFromEnd(roundsTabBody)..'\n'..lineNumber..': '..note
   })
 
   log('Adding \"'..note..'\" to Rounds on line '..lineNumber)
+end
+
+function getLatestRoundNumber()
+  local roundsTabBody = Notes.getNotebookTabs()[ROUNDS_TAB_INDEX+1].body
+  local roundNotePattern = "\n(%d+):[^\r\n]*[^\r\n%s]"
+  local lastLine = roundsTabBody:match(".*("..roundNotePattern..")")
+
+  if lastLine == nil then
+    return nil
+  end
+
+  local lastRoundNumber = tonumber(lastLine:match(roundNotePattern))
+
+  if lastRoundNumber == nil then
+    return nil
+  end
+
+  return lastRoundNumber
+end
+
+function removeNewlinesFromEnd(str)
+    return str:gsub("[\r\n]+$", "")
 end
 
 function resetRoundsNotebook()
@@ -49,17 +68,13 @@ function resetRoundsNotebook()
   })
 end
 
-function getRoundsPlayed()
-  local roundsTabBody = Notes.getNotebookTabs()[ROUNDS_TAB_INDEX+1].body
+function addSummaryNote(note)
+  local summaryNotes = Notes.getNotebookTabs()[SUMMARY_TAB_INDEX+1].body
 
-  if roundsTabBody:match'^.*():' == nil or roundsTabBody:match'^.*()\n' == nil then
-    return 0
-  end
-
-  local numberIndexEnd = roundsTabBody:match'^.*():' - 1
-  local numberIndexStart = roundsTabBody:match'^.*()\n'
-  local roundsPlayed = tonumber(string.sub(roundsTabBody, numberIndexStart, numberIndexEnd))
-  return roundsPlayed
+  Notes.editNotebookTab({
+    index = SUMMARY_TAB_INDEX,
+    body = summaryNotes..'\n'..note
+  })
 end
 
 --[[


### PR DESCRIPTION
Fixes a bug where entering a new line at the end of the Rounds notebook breaks several buttons.

Modifying the regex pattern and adding some nil checks fixes the bug.

Also fixes a nil error that appears when betting while the deck is empty.