### PR TITLE
Fix broken summing shortcuts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ This document tracks all notables changes of Havoc Tabletop Simulator Edition.
 - Fix bug where Results, Clear and Reset buttons stop working after manually modifying the Rounds notebook
   - Specifically by entering a newline at the end of the notebook
 - Fix bug where a nil operation error appears whenever a player attempts to bet when the deck is empty
+- Fix bug where summing shortcuts trigger a function-not-found error
 
 ### Removed
 

--- a/src/Shortcuts.ttslua
+++ b/src/Shortcuts.ttslua
@@ -5,9 +5,9 @@ This file contains shortcut-related functions.
 ]]
 
 function setupShortcuts()
-  addHotkey('Draw Card', drawCardShortcut)
-  addHotkey('Get Discard Sum', getDiscardSumShortcut)
-  addHotkey('Get My Sum', getMySumShortcut)
+  addHotkey("Draw Card", drawCardShortcut)
+  addHotkey("Get Discard Sum", getDiscardSumShortcut)
+  addHotkey("Get My Sum", getMySumShortcut)
   addHotkey("Get Opponent's Sum", getOpponentSumShortcut)
   addHotkey("Bet", betShortcut)
 end
@@ -33,7 +33,7 @@ function getDiscardSumShortcut()
   end
 
   log("Shortcut: get discard point sum")
-  discardZone.call('calculatePoints')
+  discardZone.call("tableCalculatePoints")
 end
 
 -- Show sum of points in player's win pile if hotkey is pressed
@@ -45,7 +45,7 @@ function getMySumShortcut(playerColor)
   end
 
   log("Shortcut: get my point sum")
-  players[playerColor].winPile.call('calculatePoints')
+  players[playerColor].winPile.call("tableCalculatePoints")
 end
 
 -- Show sum of points in opponent's win pile if hotkey is pressed
@@ -58,14 +58,14 @@ function getOpponentSumShortcut(playerColor)
 
   local opponentZone = nil
 
-  if playerColor == 'Orange' then
-    opponentZone = players['Blue'].winPile
+  if playerColor == "Orange" then
+    opponentZone = players["Blue"].winPile
   else
-    opponentZone = players['Orange'].winPile
+    opponentZone = players["Orange"].winPile
   end
 
   log("Shortcut: get opponent point sum")
-  opponentZone.call('calculatePoints')
+  opponentZone.call("tableCalculatePoints")
 end
 
 -- Trigger bet button based on the given color


### PR DESCRIPTION
The summing shortcuts trigger an error because the function they relied on was renamed.

Fixing the function names fixes the shortcuts.