### PR TITLE
Add play-card-from-hand shortcuts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,10 +9,8 @@ This document tracks all notables changes of Havoc Tabletop Simulator Edition.
 ### Added
 
 - Highlight four-of-a-kinds in win piles
-
-### Fixed
-
-- Fix onObjectLeaveZone error messages when quitting to the TTS main menu
+- New shortcut: press 1 or 2 when hovering over a card in your hand to quickly play it on the field
+  - The key pressed corresponds to where the card will be placed on the board
 
 ---
 

--- a/TTS Object Scripts/Global.-1.lua
+++ b/TTS Object Scripts/Global.-1.lua
@@ -1,1 +1,1 @@
-require("src/Main")
+require("src/Havoc")

--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -64,6 +64,9 @@ BUTTON_TEXT_COLOR = BLACK
 BUTTON_WARNING_BACKGROUND_COLOR = RED
 BUTTON_WARNING_TEXT_COLOR = WHITE
 
+-- Card color contants
+FOUR_OF_A_KIND_HIGHLIGHT_COLOR = BRIGHT_PURPLE
+
 -- Button attributes
 SMALL_BUTTON_WIDTH = 900
 STANDARD_BUTTON_WIDTH = 1200
@@ -89,8 +92,10 @@ PLAYER_HAS_NO_COLOR_BROADCAST_MESSAGE = 'The player does not have a color'
 PLAYER_HAS_NO_COLOR_LOG_MESSAGE = 'A player with no color tried to press results button'
 BET_BUTTON_TOOLTIP_MESSAGE = 'Bet to risk extra cards'
 
--- Card constants
-FOUR_OF_A_KIND_HIGHLIGHT_COLOR = BRIGHT_PURPLE
+-- Shortcut constants
+PLAY_CARD_X_OFFSET = 2
+PLAY_CARD_Y_OFFSET = 3
+PLAY_CARD_Z_OFFSET = 3
 
 -- Misc
 NUM_OF_ZONES_FOR_FIELD_CARDS = 1 -- The number of zones which a card on the field should be in

--- a/src/Shortcuts.lua
+++ b/src/Shortcuts.lua
@@ -80,6 +80,84 @@ function betShortcut(playerColor)
   playerBet(playerColor, playerColor)
 end
 
+-- Overwrites default behavior and setup some shortcuts when number keys are pressed on cards
+function onObjectNumberTyped(object, player_color, number)
+  if object.tag != 'Card' then
+    return
+  end
+  
+  if isObjectHeldBy(object, player_color) == true then
+    if number == 1 or number == 2 then
+      playCardFromHand(object, player_color, number)
+    end
+  end
+  
+  return true
+end
+
+-- Check if the given object is in the player's hand zone
+function isObjectHeldBy(object, player_color)
+  local handZone = players[player_color].hand
+
+  for _, item in pairs(handZone.getObjects()) do
+    if item == object then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- Move a card from a player's hand to the field based on the key pressed
+-- Only keys "1" and "2" are supported
+function playCardFromHand(object, player_color, key_pressed)
+  if object.tag != 'Card' then
+    return
+  end
+
+  if player_color ~= 'Orange' and player_color ~= 'Blue' then
+    return
+  end
+
+  if object.is_face_down == true then
+    object.flip()
+  end
+
+  local x_offset = PLAY_CARD_X_OFFSET
+  local y_offset = PLAY_CARD_Y_OFFSET
+  local z_offset = PLAY_CARD_Z_OFFSET
+
+  orange_field_card_slots = {
+    { 1, {-x_offset, y_offset, -z_offset} },
+    { 2, {x_offset, y_offset, -z_offset} }
+  }
+
+  blue_field_card_slots = {
+    { 1, {x_offset, y_offset, z_offset} },
+    { 2, {-x_offset, y_offset, z_offset} }
+  }
+
+  -- Get card slot positions based on player color
+  local slots = nil
+
+  if player_color == 'Orange' then
+    slots = orange_field_card_slots
+  elseif player_color == 'Blue' then
+    slots = blue_field_card_slots
+  end
+
+  -- Get the new card position based on the number pressed
+  for i, slot_data in pairs(slots) do
+    local slot_key = slot_data[1]
+    local slot_position = slot_data[2]
+
+    if slot_key == key_pressed then
+      object.setPosition(slot_position)
+      return 
+    end
+  end
+end
+
 --[[
 Shortcuts.lua END
 ]]


### PR DESCRIPTION
Players can now press  "1" or "2" on their keyboards when hovering over a card in their hands to quickly play the card on the field to designated spots.

If cards are face down when moved, then they are flipped so that they are face up.